### PR TITLE
Correted Oh Shit Git link markup

### DIFF
--- a/Links/Version Control/Git.md
+++ b/Links/Version Control/Git.md
@@ -1,1 +1,1 @@
-[Oh Shit, Git!?!][https://ohshitgit.com/]
+[Oh Shit, Git!?!](https://ohshitgit.com/)


### PR DESCRIPTION
Since the markup wasn't correct, the link pointed to the same page instead of the "oh shit git" page.